### PR TITLE
S6 t1/returning all meetings/appointments stub

### DIFF
--- a/server/models/handlers/appointment.js
+++ b/server/models/handlers/appointment.js
@@ -11,6 +11,70 @@ async function bookAppointment(studentId, workerTimeslotId, purpose, studentNote
     }
 };
 
+// Fetches all the essential appointment details for a student and returns the appointmentId in case more information is desired.
+// Note that only the minimal appointment details is returned to reduce the size of the payload (and avoid exceeding the payload size if the number of appointments increase).
+async function getAppointmentDetailsForStudent(studentId, status) {
+    const appointmentDetails = [
+        {
+            appointmentId: 1,
+            worker: {
+                firstName: 'Tyler',
+                lastName: 'Evans',
+            },
+            date: '2020-11-05',
+            startTime: '08:00:00',
+            endTime: '08:30:00',
+            status: 'upcoming',
+        },
+        {
+            appointmentId: 2,
+            worker: {
+                firstName: 'Joshua',
+                lastName: 'Brooks',
+            },
+            date: '2020-11-07',
+            startTime: '08:30:00',
+            endTime: '09:00:00',
+            status: 'upcoming',
+        },
+    ];
+
+    return appointmentDetails;
+}
+
+// Fetches all the essential appointment details for a student and returns the appointmentId in case more information is desired.
+// Note that only the minimal appointment details is returned to reduce the size of the payload (and avoid exceeding the payload size if the number of appointments increase).
+async function getAppointmentDetailsForWorker(workerId, status) {
+    const appointmentDetails = [
+        {
+            appointmentId: 1,
+            student: {
+                firstName: 'John',
+                lastName: 'Doe',
+            },
+            date: '2020-11-05',
+            startTime: '08:00:00',
+            endTime: '08:30:00',
+            status: 'upcoming',
+        },
+        {
+            appointmentId: 3,
+            student: {
+                firstName: 'Jane',
+                lastName: 'Smith',
+            },
+            date: '2020-11-05',
+            startTime: '08:30:00',
+            endTime: '09:00:00',
+            status: 'upcoming',
+        },
+    ];
+
+    return appointmentDetails;
+}
+
 module.exports = {
     bookAppointment,
+    getAppointmentDetailsForStudent,
+    getAppointmentDetailsForWorker,
 }

--- a/server/routes/private.js
+++ b/server/routes/private.js
@@ -104,6 +104,37 @@ router.post('/api/worker-availability', async (req, res) => {
 
 });
 
+// Returns all the appointments/meetings for a given student or worker.
+// Note that appointments/meetings are synonymous, but only appointments will be used in the backend to maintain consistency.
+router.get('/api/appointments', async (req, res) => {
+    const paramSchema = Joi.object({
+        studentId: Joi.number().integer(),
+        workerId: Joi.number().integer(), 
+        status: Joi.array().items(Joi.string()) // Optional parameter and will default to only upcoming if not specified.
+    }).xor('studentId', 'workerId'); // Either the studentId or the workerId must be specified (they both cannot be specified).
+
+    const query = req.query ? req.query : {};
+
+    const studentId = query.studentId;
+    const workerId = query.workerId;
+    // Should leave the status as is if it is null/undefined/already an array. Else, converts it to an array 
+    // Due to Postman limitations to work around passing in an array in the query params.
+    const status = (_.isNil(query.status) || _.isArray(query.status)) ? query.status : [query.status];
+
+    const { error } = paramSchema.validate({ studentId, workerId, status });
+
+    if (!_.isNil(error)) res.send(error);
+
+    let appointmentDetails = [];
+
+    // Separate methods for the student and worker appointments as they return different parameters in the object (to reduce redundancy and size of response).
+    // Additionally these methods return details beyond the bare appointment details and thus were not named as only getAppointments to avoid confusion.
+    if (!_.isNil(studentId)) appointmentDetails = await appointmentHandler.getAppointmentDetailsForStudent(studentId, status);
+    else appointmentDetails = await appointmentHandler.getAppointmentDetailsForWorker(workerId, status);
+
+    res.send(appointmentDetails);
+});
+
 router.get('/test', async (req, res) => {
     res.send(true);
 });

--- a/server/routes/private.js
+++ b/server/routes/private.js
@@ -110,7 +110,7 @@ router.get('/api/appointments', async (req, res) => {
     const paramSchema = Joi.object({
         studentId: Joi.number().integer(),
         workerId: Joi.number().integer(), 
-        status: Joi.array().items(Joi.string()) // Optional parameter and will default to only upcoming if not specified.
+        status: Joi.array().items(Joi.string().min(1).max(300)) // Optional parameter and will default to only upcoming if not specified.
     }).xor('studentId', 'workerId'); // Either the studentId or the workerId must be specified (they both cannot be specified).
 
     const query = req.query ? req.query : {};

--- a/server/test/handlers/getAppointments.test.js
+++ b/server/test/handlers/getAppointments.test.js
@@ -1,0 +1,80 @@
+const appointmentHandler = require('../../models/handlers/appointment');
+
+describe('testing getting appointment details functionality', () => {
+    beforeEach(() => {
+        jest.resetModules();
+    });
+
+    test('initial setup of getting appointment details for a student', async() => {
+        // Arrange
+        const studentId = '12345678';
+        const status = 'upcoming';
+        const testAppointmentDetails = [
+            {
+                appointmentId: 1,
+                worker: {
+                    firstName: 'Tyler',
+                    lastName: 'Evans',
+                },
+                date: '2020-11-05',
+                startTime: '08:00:00',
+                endTime: '08:30:00',
+                status: 'upcoming',
+            },
+            {
+                appointmentId: 2,
+                worker: {
+                    firstName: 'Joshua',
+                    lastName: 'Brooks',
+                },
+                date: '2020-11-07',
+                startTime: '08:30:00',
+                endTime: '09:00:00',
+                status: 'upcoming',
+            },
+        ];
+
+        // Act
+        const appointmentDetails = await appointmentHandler.getAppointmentDetailsForStudent(studentId, status);
+
+        // Assert
+        expect(appointmentDetails).toMatchObject(testAppointmentDetails);
+    });
+
+    test('initial setup of getting appointment details for a worker', async() => {
+        // Arrange
+        const workerId = '12345678';
+        const status = 'upcoming';
+        const testAppointmentDetails = [
+            {
+                appointmentId: 1,
+                student: {
+                    firstName: 'John',
+                    lastName: 'Doe',
+                },
+                date: '2020-11-05',
+                startTime: '08:00:00',
+                endTime: '08:30:00',
+                status: 'upcoming',
+            },
+            {
+                appointmentId: 3,
+                student: {
+                    firstName: 'Jane',
+                    lastName: 'Smith',
+                },
+                date: '2020-11-05',
+                startTime: '08:30:00',
+                endTime: '09:00:00',
+                status: 'upcoming',
+            },
+        ];
+
+        // Act
+        const appointmentDetails = await appointmentHandler.getAppointmentDetailsForWorker(workerId, status);
+
+        // Assert
+        expect(appointmentDetails).toMatchObject(testAppointmentDetails);
+    });
+
+}); 


### PR DESCRIPTION
**Scrum Board Ticket:** S6 T1: Create a stub for fetching all the meetings/appointments for a given user

**Story:** Story 6 Meeting/Appointment Descriptions

**Description:** Added a _private_ endpoint that returns static values for the worker and student upcoming appointments and requires  EITHER `studentId` OR `workerId` (NOT both but one is required). The parameter `status` is also available for this endpoint to make it more versatile for future functionalities. 

**Testing Criteria:** Tested code by running locally. Also ensured that all automated tests in Jest passed and had 100% file coverage (run `npm test` in the server folder). I also sent requests to the `/api/appointments` endpoint with numerical and string values for the query parameters `workerId`, `studentId`, and `status` on Postman. I tried different combinations and ensured that the response was as expected: 
- If both `workerId` and `studentId` => throw error
- If `workerId` is string => throw error
- If `studentId` is string => throw error
- If `workerId` is numerical (e.g. 8000000), then response includes student
- If `studentId` is numerical (e.g. 12345678), then response includes worker
- If status is a string or not specified => accept 
- An array of strings for status => accept (for Postman, array is specified by declaring multiple values for the specific parameter as shown below).
![image](https://user-images.githubusercontent.com/32720322/97647312-4a26c180-1a28-11eb-8984-cfb04778b9e7.png)

**How Reviewers can Test Code:**
1. Run the code locally (navigate inside the `server` folder and run `npm start`) and test the `/api/appointments` endpoint on localhost port 4000 using Postman with various combinations of query parameters `studentId`, `workerId` and `status` to ensure that the response is as expected for numerical values and string values (refer to above list for examples).
**_Make sure to pass in an accessToken when making the Postman calls as this is a private endpoint (e.g. `accessToken: XcCa92ZvOnQKZsGtOKOa`)._**
2. Run the automated tests in Jest to make sure that all tests pass and have 100% file coverage. To do this, navigate inside the `server` folder and run `npm test`. Please note that tests have not been setup for the front end so an error will occur if one attempts to run `npm test` in the root folder.