### PR TITLE
S5 t2/create frontend cancellation page

### DIFF
--- a/react-ui/package-lock.json
+++ b/react-ui/package-lock.json
@@ -5453,6 +5453,11 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -15856,6 +15861,22 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
       "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-modal": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.2.tgz",
+      "integrity": "sha512-o8gvvCOFaG1T7W6JUvsYjRjMVToLZgLIsi5kdhFIQCtHxDkA47LznX62j+l6YQkpXDbvQegsDyxe/+JJsFQN7w==",
+      "requires": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.5.10",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      }
+    },
     "react-router": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
@@ -19334,6 +19355,14 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/react-ui/package.json
+++ b/react-ui/package.json
@@ -14,6 +14,7 @@
     "react": "^16.13.1",
     "react-dom": "^17.0.1",
     "react-grid-system": "^7.1.1",
+    "react-modal": "^3.11.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "2.0.0",
     "react-test-renderer": "^17.0.1"

--- a/react-ui/src/components/Common/ColorSchema.scss
+++ b/react-ui/src/components/Common/ColorSchema.scss
@@ -8,3 +8,8 @@ $student-active-color: #2bb4d6;
 $worker-color: #c6538c;
 $worker-hover-color: #dd89b3;
 $worker-active-color: #d31976;
+
+$emergency-btn-color: rgb(255, 175, 25);
+
+$typical-font-size: 20px;
+$input-font-size: 16px;

--- a/react-ui/src/components/EmergencyDayCancellation/EmergencyDayCancellation.js
+++ b/react-ui/src/components/EmergencyDayCancellation/EmergencyDayCancellation.js
@@ -1,0 +1,94 @@
+import React, { Component } from "react";
+import queryString from 'query-string';
+import _ from 'lodash';
+import Modal from 'react-modal';
+
+import "./EmergencyDayCancellation.scss";
+
+const axios = require('axios').default;
+var moment = require('moment');
+
+export default class EmergencyDayCancellation extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            showModal: false,
+            isSuccessfullyCancelled: false,
+            cancelledDate: '',
+        }
+
+        // Binds methods to prevent issues with 'this' keyword.
+        this.showModal = this.showModal.bind(this);
+        this.closeModal = this.closeModal.bind(this);
+        this.handleCancelledDateInput = this.handleCancelledDateInput.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+        this.cancelAppointments = this.cancelAppointments.bind(this);
+    }
+
+    showModal() {
+        this.setState({ showModal: true })
+    }
+
+    closeModal() {
+        this.setState({ showModal: false })
+    }
+
+    // Stores the latest value of the cancelled date to the state variable.
+    handleCancelledDateInput(event) {
+        const val = event.target.value;
+        this.setState({
+            cancelledDate: val
+        });
+    };
+
+    // Handles form submission logic and cancels the worker's appointments for the specified date.
+    async handleSubmit(e) {
+        e.preventDefault();
+
+        await this.cancelAppointments();
+        this.closeModal();
+    }
+
+    // Calls the back end endpoint to cancel all the worker's appointments for the specific date.
+    async cancelAppointments() {
+        const cancelledDate = this.state.cancelledDate;
+        const params = { accessToken: this.props.user.accessToken, workerId: this.props.user.personId, specificDate: cancelledDate };
+        // Formats the date for better readability.
+        const formattedCancelledDate = moment(cancelledDate).format('dddd, MMM D, YYYY');
+
+        await axios.get(`/api/cancel-specific-day/?${queryString.stringify(params)}`)
+            .then(res => {
+                if (_.isNil(res.error) && res.data) { // If no error and the returned response is true.
+                    // Display the appropriate alert box based on whether the appointments were successfully cancelled.
+                    alert(`Success!\nAll appointments for ${formattedCancelledDate} have been cancelled!`);
+                } else alert(`Error!\nAn issue occurred when trying to cancel all appointments for ${formattedCancelledDate}.\nPlease try again!`);
+            });
+    }
+
+    render() {
+        return (
+            <div>
+                <button className="cancelAppointmentBtn" onClick={this.showModal}>Cancel All Appointments for a Specific Day</button>
+                {/* Only displays the modal if the user has clicked the button to show the form. */}
+                <Modal isOpen={this.state.showModal}>
+                    <button onClick={this.closeModal} className="closeBtn">X</button>
+                    <h1 align="center">Cancel Appointments for Specific Day</h1>
+                    <form onSubmit={this.handleSubmit} className="cancelDayForm">
+                        <label>Select the Specific Day: </label>
+                        <input
+                            type="date"
+                            min={new Date().toISOString().split('T')[0]}
+                            required
+                            className="cancelledDateInput"
+                            onChange={this.handleCancelledDateInput} /> <br />
+                        <input
+                            className="submitBtn"
+                            type="submit"
+                            value="Cancel Day's Appointments" />
+                    </form>
+                </Modal>
+            </div>
+        );
+
+    }
+}

--- a/react-ui/src/components/EmergencyDayCancellation/EmergencyDayCancellation.scss
+++ b/react-ui/src/components/EmergencyDayCancellation/EmergencyDayCancellation.scss
@@ -1,0 +1,36 @@
+@import "../Common/ColorSchema.scss";
+
+.cancelAppointmentBtn {
+    background-color: $emergency-btn-color;
+    position: absolute;
+    right: 0;
+    padding: 5px;
+    margin-right: 10px;
+    font-size: $typical-font-size;   
+}
+
+.closeBtn {
+    float: right;
+    padding: 20px;
+    font-size: $typical-font-size;
+    background-color: $worker-active-color;
+}
+
+.cancelDayForm {
+    display: block;
+    text-align: center;
+    font-size: $typical-font-size;
+    margin-top: 5%;
+}
+
+.cancelledDateInput {
+    text-align: center;
+    font-size: $input-font-size;
+}
+
+.submitBtn {
+    background-color: $emergency-btn-color;
+    margin-top: 5%;
+    padding: 1%;
+    font-size: $typical-font-size;
+}

--- a/react-ui/src/components/EmergencyDayCancellation/EmergencyDayCancellation.test.js
+++ b/react-ui/src/components/EmergencyDayCancellation/EmergencyDayCancellation.test.js
@@ -168,4 +168,26 @@ describe('EmergencyDayCancellation component', () => {
         expect(window.alert).toHaveBeenCalledWith(failedMsg);
     });
 
+    test('rejection of an inputted date that is in the past', async () => {
+        const testUser = {
+            userType: 'worker',
+            personId: '8000000',
+            accessToken: 'XcCa92ZvOnQKZsGtOKOa',
+        };
+        const selectedDate = '2019-10-11'
+        const failedMsg = "Error!\nAn issue occurred when trying to cancel all appointments for Friday, Oct 11, 2019.\nPlease try again!";
+        window.alert = jest.fn();
+
+        // Act
+        const testRenderer = TestRenderer.create(<EmergencyDayCancellation user={testUser} />);
+        const testInstance = testRenderer.root;
+        ReactDOM.createPortal = node => node; // Needed to mock the portal parent for clicking.
+        testInstance.findByProps({ className: "cancelAppointmentBtn" }).props.onClick(); // Opens the modal.
+        testInstance.findByProps({ className: "cancelledDateInput" }).props.onChange({ target: { value: selectedDate } }); // Simulates user input of date.
+        await testInstance.findByProps({ className: "cancelDayForm" }).props.onSubmit({ preventDefault: () => { } }); // Submits the form.
+
+        // Arrange
+        expect(window.alert).toHaveBeenCalledWith(failedMsg);
+    });
+
 });

--- a/react-ui/src/components/EmergencyDayCancellation/EmergencyDayCancellation.test.js
+++ b/react-ui/src/components/EmergencyDayCancellation/EmergencyDayCancellation.test.js
@@ -104,6 +104,31 @@ describe('EmergencyDayCancellation component', () => {
         expect(window.alert).toHaveBeenCalledWith(failedMsg);
     });
 
+    test('error returned in the axios call', async () => {
+        // Arrange
+        const testUser = {
+            userType: 'worker',
+            personId: '8000000',
+            accessToken: 'XcCa92ZvOnQKZsGtOKOa',
+        };
+        const selectedDate = '2020-12-15';
+        const resp = { data: true, error: "Unknown error" };
+        const failedMsg = "Error!\nAn issue occurred when trying to cancel all appointments for Tuesday, Dec 15, 2020.\nPlease try again!";
+        axios.get.mockImplementation(() => Promise.resolve(resp));
+        window.alert = jest.fn();
+
+        // Act
+        const testRenderer = TestRenderer.create(<EmergencyDayCancellation user={testUser} />);
+        const testInstance = testRenderer.root;
+        ReactDOM.createPortal = node => node; // Needed to mock the portal parent for clicking.
+        testInstance.findByProps({ className: "cancelAppointmentBtn" }).props.onClick(); // Opens the modal.
+        testInstance.findByProps({ className: "cancelledDateInput" }).props.onChange({ target: { value: selectedDate } }); // Simulates user input of date.
+        await testInstance.findByProps({ className: "cancelDayForm" }).props.onSubmit({ preventDefault: () => { } }); // Submits the form.
+
+        // Arrange
+        expect(window.alert).toHaveBeenCalledWith(failedMsg);
+    });
+
     test('submission of the cancellation modal with no user props but a date is inputted', async () => {
         // Arrange
         const selectedDate = '2020-12-15';

--- a/react-ui/src/components/EmergencyDayCancellation/EmergencyDayCancellation.test.js
+++ b/react-ui/src/components/EmergencyDayCancellation/EmergencyDayCancellation.test.js
@@ -1,0 +1,171 @@
+import React from "react";
+import { create } from "react-test-renderer";
+import { render, waitFor, cleanup, fireEvent } from '@testing-library/react';
+import * as axios from 'axios';
+import Modal from 'react-modal';
+import ReactDOM from 'react-dom';
+import TestRenderer from 'react-test-renderer';
+
+import EmergencyDayCancellation from './EmergencyDayCancellation';
+
+jest.mock('axios');
+
+describe('EmergencyDayCancellation component', () => {
+    afterEach(cleanup);
+
+    beforeEach(() => {
+        jest.resetModules(); // Clears any cache between tests.
+    });
+
+    test('Snapshot successfully renders', () => {
+        // Arrange
+        // No variables needed for this test case.
+
+        // Act
+        const component = create(<EmergencyDayCancellation />);
+
+        // Assert
+        expect(component.toJSON()).toMatchSnapshot();
+    });
+
+    test('modal not initially shown', () => {
+        // Arrange
+        const isInitialModalShown = false;
+
+        // Act
+        const testRenderer = TestRenderer.create(<EmergencyDayCancellation />);
+        const testInstance = testRenderer.root;
+
+        // Arrange
+        expect(testInstance.findByType(Modal).props.isOpen).toBe(isInitialModalShown);
+    });
+
+    test('modal shown after appropriate button click', () => {
+        // Arrange
+        const isModalShownAfterClick = true;
+
+        // Act
+        const testRenderer = TestRenderer.create(<EmergencyDayCancellation />);
+        const testInstance = testRenderer.root;
+        ReactDOM.createPortal = node => node; // Needed to mock the portal parent for clicking.
+        testInstance.findByProps({ className: "cancelAppointmentBtn" }).props.onClick();
+
+        // Arrange
+        expect(testInstance.findByType(Modal).props.isOpen).toBe(isModalShownAfterClick);
+    });
+
+    test('successful submission of the cancellation modal with a date inputted with correct user props', async () => {
+        // Arrange
+        const testUser = {
+            userType: 'worker',
+            personId: '8000000',
+            accessToken: 'XcCa92ZvOnQKZsGtOKOa',
+        };
+        const selectedDate = '2020-12-15';
+        const resp = { data: true };
+        const successfulSubmissionMsg = "Success!\nAll appointments for Tuesday, Dec 15, 2020 have been cancelled!";
+        axios.get.mockImplementation(() => Promise.resolve(resp));
+        window.alert = jest.fn();
+
+        // Act
+        const testRenderer = TestRenderer.create(<EmergencyDayCancellation user={testUser} />);
+        const testInstance = testRenderer.root;
+        ReactDOM.createPortal = node => node; // Needed to mock the portal parent for clicking.
+        testInstance.findByProps({ className: "cancelAppointmentBtn" }).props.onClick(); // Opens the modal.
+        testInstance.findByProps({ className: "cancelledDateInput" }).props.onChange({ target: { value: selectedDate } }); // Simulates user input of date.
+        await testInstance.findByProps({ className: "cancelDayForm" }).props.onSubmit({ preventDefault: () => { } }); // Submits the form.
+
+        // Arrange
+        expect(window.alert).toHaveBeenCalledWith(successfulSubmissionMsg);
+    });
+
+    test('failed submission of the cancellation modal with a date inputted with correct user props', async () => {
+        // Arrange
+        const testUser = {
+            userType: 'worker',
+            personId: '8000000',
+            accessToken: 'XcCa92ZvOnQKZsGtOKOa',
+        };
+        const selectedDate = '2020-12-15';
+        const resp = { data: false };
+        const failedMsg = "Error!\nAn issue occurred when trying to cancel all appointments for Tuesday, Dec 15, 2020.\nPlease try again!";
+        axios.get.mockImplementation(() => Promise.resolve(resp));
+        window.alert = jest.fn();
+
+        // Act
+        const testRenderer = TestRenderer.create(<EmergencyDayCancellation user={testUser} />);
+        const testInstance = testRenderer.root;
+        ReactDOM.createPortal = node => node; // Needed to mock the portal parent for clicking.
+        testInstance.findByProps({ className: "cancelAppointmentBtn" }).props.onClick(); // Opens the modal.
+        testInstance.findByProps({ className: "cancelledDateInput" }).props.onChange({ target: { value: selectedDate } }); // Simulates user input of date.
+        await testInstance.findByProps({ className: "cancelDayForm" }).props.onSubmit({ preventDefault: () => { } }); // Submits the form.
+
+        // Arrange
+        expect(window.alert).toHaveBeenCalledWith(failedMsg);
+    });
+
+    test('submission of the cancellation modal with no user props but a date is inputted', async () => {
+        // Arrange
+        const selectedDate = '2020-12-15';
+        var isThrown = false;
+        const resp = { data: false };
+        axios.get.mockImplementation(() => Promise.resolve(resp));
+
+        // Act
+        try {
+            const testRenderer = TestRenderer.create(<EmergencyDayCancellation />);
+            const testInstance = testRenderer.root;
+            ReactDOM.createPortal = node => node; // Needed to mock the portal parent for clicking.
+            testInstance.findByProps({ className: "cancelAppointmentBtn" }).props.onClick(); // Opens the modal.
+            testInstance.findByProps({ className: "cancelledDateInput" }).props.onChange({ target: { value: selectedDate } }); // Simulates user input of date.
+            await testInstance.findByProps({ className: "cancelDayForm" }).props.onSubmit({ preventDefault: () => { } }); // Submits the form.
+        } catch (err) {
+            isThrown = true;
+        }
+
+        // Arrange
+        expect(isThrown).toBe(true);
+    });
+
+    test('submission of the cancellation modal with invalid date inputted and correct user props', async () => {
+        const testUser = {
+            userType: 'worker',
+            personId: '8000000',
+            accessToken: 'XcCa92ZvOnQKZsGtOKOa',
+        };
+        const failedMsg = "Error!\nAn issue occurred when trying to cancel all appointments for Invalid date.\nPlease try again!";
+        window.alert = jest.fn();
+
+        // Act
+        const testRenderer = TestRenderer.create(<EmergencyDayCancellation user={testUser} />);
+        const testInstance = testRenderer.root;
+        ReactDOM.createPortal = node => node; // Needed to mock the portal parent for clicking.
+        testInstance.findByProps({ className: "cancelAppointmentBtn" }).props.onClick(); // Opens the modal.
+        testInstance.findByProps({ className: "cancelledDateInput" }).props.onChange({ target: { value: "YYYY-MM-DD" } }); // Empty value for the date.
+        await testInstance.findByProps({ className: "cancelDayForm" }).props.onSubmit({ preventDefault: () => { } }); // Submits the form.
+
+        // Arrange
+        expect(window.alert).toHaveBeenCalledWith(failedMsg);
+    });
+
+    test('submission of the cancellation modal with no date inputted and correct user props', async () => {
+        const testUser = {
+            userType: 'worker',
+            personId: '8000000',
+            accessToken: 'XcCa92ZvOnQKZsGtOKOa',
+        };
+        const failedMsg = "Error!\nAn issue occurred when trying to cancel all appointments for Invalid date.\nPlease try again!";
+        window.alert = jest.fn();
+
+        // Act
+        const testRenderer = TestRenderer.create(<EmergencyDayCancellation user={testUser} />);
+        const testInstance = testRenderer.root;
+        ReactDOM.createPortal = node => node; // Needed to mock the portal parent for clicking.
+        testInstance.findByProps({ className: "cancelAppointmentBtn" }).props.onClick(); // Opens the modal.
+        await testInstance.findByProps({ className: "cancelDayForm" }).props.onSubmit({ preventDefault: () => { } }); // Submits the form.
+
+        // Arrange
+        expect(window.alert).toHaveBeenCalledWith(failedMsg);
+    });
+
+});

--- a/react-ui/src/components/EmergencyDayCancellation/__snapshots__/EmergencyDayCancellation.test.js.snap
+++ b/react-ui/src/components/EmergencyDayCancellation/__snapshots__/EmergencyDayCancellation.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EmergencyDayCancellation component Snapshot successfully renders 1`] = `
+<div>
+  <button
+    className="cancelAppointmentBtn"
+    onClick={[Function]}
+  >
+    Cancel All Appointments for a Specific Day
+  </button>
+</div>
+`;

--- a/react-ui/src/components/Layouts/Home.js
+++ b/react-ui/src/components/Layouts/Home.js
@@ -2,11 +2,15 @@ import React, { Component, Fragment } from "react";
 
 import Title from "../Title"
 import AppointmentList from "../AppointmentList/AppointmentList";
+import EmergencyDayCancellation from "../EmergencyDayCancellation/EmergencyDayCancellation";
+
+import UserTypes from '../../constants/userTypes.json';
 
 class Home extends Component {
   render() {
     return (
       <Fragment>
+        {this.props.userType === UserTypes.worker && <EmergencyDayCancellation user={this.props}/> }
         <Title name="Welcome"/>
         <AppointmentList user={this.props} />
       </Fragment>


### PR DESCRIPTION
**Scrum Board Ticket:** S5 T2: Implement the front end cancellation page

**Story:** Story 5 Cancel specific day 

**Description:** Created a component on the worker home page that allows them to cancel their appointments for a specific day.

**Testing Criteria (how I tested the code):** 
1. Ran the code locally and ensured that the Home page for a worker user displays the appropriate button for workers to cancel their appointments for a specific day (as shown below). Manually clicked the button and tested various combinations and ensured that the response was as expected, i.e., Success popup for valid dates and error popup for invalid dates. Also tested historical dates to ensure that previous dates are not accepted.
![image](https://user-images.githubusercontent.com/32720322/99133468-2185f680-25e8-11eb-8ea9-f107088dd133.png)
2. Ran the code locally and ensured that the Home page for the student user does NOT display the appropriate button to allow them to cancel their appointments for a specific day.
3. Ran the unit tests in the front end and ensured 100% file coverage (and passing tests) for the `EmergencyDayCancellation.js`, `AppointmentList.js`, `LogIn.js` and `CheckboxApplication.js` components. The other tests are not set up yet (in the scope of another ticket) and thus the low file coverage for the other front end files is expected.
4. Ran the automated server test codes and ensured that there was 100% file coverage (and passing tests) for all the unit tests. Please note that `account.js` has slightly lower than 100% file coverage and is being addressed in another ticket.

**How Reviewers can Test Code:**
1. Run the code locally and ensure no complications when starting up (run the command `npm run-script start:dev` in the root folder OR run the command `npm start` if your node and npm versions are above 12.10.0 for node and 6.10.3 for npm).
a. Use student credentials such as `username: johndoe@gmail.com and password: a1234`. There should NOT be a button to allow the user to cancel their appointments for a specific date.
b. Use worker credentials such as `username: joshuabrooks@gmail.com and password: j1234`. There should be a button to allow the user to cancel their appointments for a specific date. Click the button and ensure that the modal shows up similar to the below picture. Try different combinations of dates and ensure that the response is as expected. 
![image](https://user-images.githubusercontent.com/32720322/99133667-cf91a080-25e8-11eb-9a74-c41898e916da.png)
2. Run the automated tests locally and ensure that all tests pass and have 100% file coverage. 
a. Navigate inside the `server` folder and run `npm test`. 
b. Navigate inside the `react-ui` folder and run `npm test`. All tests should pass and for the `EmergencyDayCancellation.js`, `AppointmentList.js`, `LogIn.js` and `CheckboxApplication.js` components should have 100% file coverage (the rest are not set up yet and are in the scope for another ticket).