### PR TITLE
S19 t1/cancelling meetings frontend

### DIFF
--- a/react-ui/package-lock.json
+++ b/react-ui/package-lock.json
@@ -4862,11 +4862,6 @@
         }
       }
     },
-    "email-validator": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
-      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ=="
-    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -15699,6 +15694,11 @@
           "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
         }
       }
+    },
+    "react-confirm-alert": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/react-confirm-alert/-/react-confirm-alert-2.6.2.tgz",
+      "integrity": "sha512-lvlk+Sic7p3wbOcsetkCHVXA3LJCDViqjO8sV7FtCfJwjw36ZKCJv2FiaxUCiw3g8PXvmpjEtvAvLqPKb8yh/A=="
     },
     "react-dev-utils": {
       "version": "6.1.1",

--- a/react-ui/package.json
+++ b/react-ui/package.json
@@ -12,6 +12,7 @@
     "node-sass": "^4.14.1",
     "query-string": "^6.13.6",
     "react": "^16.13.1",
+    "react-confirm-alert": "^2.6.2",
     "react-dom": "^17.0.1",
     "react-grid-system": "^7.1.1",
     "react-modal": "^3.11.2",

--- a/react-ui/src/components/AppointmentList/AppointmentList.js
+++ b/react-ui/src/components/AppointmentList/AppointmentList.js
@@ -54,7 +54,7 @@ export default class AppointmentList extends Component {
           label: 'Yes',
           className: "yes-cancel-btn",
           onClick: () => {
-            alert('The appointment was NOT cancelled. Please try again.');
+            alert("The appointment was NOT cancelled!\r\n\nThis feature is not fully integrated yet, but the ConnectMe team is working hard to finish it. We appreciate your patience!");
 
             /* TO DO: UNCOMMENT LOGIC ONCE INTEGRATE WITH API.
              // Stores whether the appointment was successfully cancelled in a variable. 

--- a/react-ui/src/components/AppointmentList/AppointmentList.js
+++ b/react-ui/src/components/AppointmentList/AppointmentList.js
@@ -1,8 +1,11 @@
-import React, { Component, Fragment } from "react";
+import React, { Component } from "react";
 import queryString from 'query-string'
 import _ from 'lodash';
+import { confirmAlert } from 'react-confirm-alert';
 
+import 'react-confirm-alert/src/react-confirm-alert.css';
 import "./AppointmentList.scss";
+
 import UserTypes from '../../constants/userTypes.json';
 
 const axios = require('axios').default;
@@ -14,6 +17,9 @@ export default class AppointmentList extends Component {
     this.state = {
       appointments: []
     }
+
+    // Binds methods to prevent issues with 'this' keyword.
+    this.cancelAppointment = this.cancelAppointment.bind(this);
   }
 
   // Make a call to get all the appointments for the user.
@@ -38,6 +44,50 @@ export default class AppointmentList extends Component {
       });
   }
 
+  async cancelAppointment(event) {
+    // Customizes the content in the cancel appointment popup.
+    const options = {
+      title: 'Appointment Cancellation Confirmation',
+      message: 'Are you sure you want to cancel this appointment?',
+      buttons: [
+        {
+          label: 'Yes',
+          className: "yes-cancel-btn",
+          onClick: () => {
+            alert('The appointment was NOT cancelled. Please try again.');
+
+            /* TO DO: UNCOMMENT LOGIC ONCE INTEGRATE WITH API.
+             // Stores whether the appointment was successfully cancelled in a variable. 
+            const isSuccessfullyCancelled = false;
+            // Stores the specific appointmentId as a variable for API call. 
+            const appointmentId = event.target.id;
+
+            // TO DO: Call the API to cancel the appointment
+            console.log('cancelAppointment', appointmentId);
+
+            // Display a success message if the appointment is successfully cancelled.
+            if (isSuccessfullyCancelled) alert('The appointment has been cancelled!');
+            // Else, let's the user know that the appointment was not cancelled successfully.
+            else alert('The appointment was NOT cancelled. Please try again.');
+            */
+          }
+        },
+        {
+          label: 'No',
+          className: "no-cancel-btn",
+          // Does not cancel the appointment and automatically closes the popup.
+          // Does not display an alert to the user to prevent unnecessary clicking.
+          // If desired in the future, uncomment following code of line. 
+
+          // onClick: () => alert('The appointment is NOT cancelled.')
+        }
+      ]
+    };
+
+    // Calls the popup to check if the user actually wanted to cancel the meeting.
+    confirmAlert(options);
+  }
+
   render() {
     // Display a message to the user if they do not have any appointments.
     if (_.isEmpty(this.state.appointments)) return <h3>No Upcoming Appointments!</h3>
@@ -59,6 +109,7 @@ export default class AppointmentList extends Component {
                       :
                       <div className="person-name">{appointment.student.firstName} {appointment.student.lastName}</div>
                     }
+                    <button className="cancel-btn" onClick={this.cancelAppointment} id={appointment.appointmentId}>Cancel</button>
                   </div>
                   <div className="times">{appointment.startTime.substring(0, 5)} to {appointment.endTime.substring(0, 5)}</div>
                 </li>

--- a/react-ui/src/components/AppointmentList/AppointmentList.scss
+++ b/react-ui/src/components/AppointmentList/AppointmentList.scss
@@ -31,3 +31,24 @@ ul, h3 {
     justify-content: flex-end;
 }
 
+.cancel-btn {
+    margin-top: 1%;
+    margin-left: 1%;
+    color: red;
+    font-size: medium;
+    font-weight: 500;
+}
+
+.react-confirm-alert-body {
+    text-align: center;
+}
+
+.react-confirm-alert-button-group {
+    justify-content: center;
+    button {
+        background: $appointment-box-color;
+        color: black;
+        font-size: 20px;
+        padding: 2% 5%;
+    }
+}

--- a/react-ui/src/components/AppointmentList/AppointmentList.test.js
+++ b/react-ui/src/components/AppointmentList/AppointmentList.test.js
@@ -390,7 +390,7 @@ describe('rendering appointment cancellation popups', () => {
       accessToken: 'eeJAQr3wEC6CJZROFJTY',
     };
     const resp = { data: appointmentDetails };
-    const submissionMsg = 'The appointment was NOT cancelled. Please try again.';
+    const submissionMsg = "The appointment was NOT cancelled!\r\n\nThis feature is not fully integrated yet, but the ConnectMe team is working hard to finish it. We appreciate your patience!";
 
     axios.get.mockImplementation(() => Promise.resolve(resp));
     window.alert = jest.fn();


### PR DESCRIPTION
**Scrum Board Ticket:** S19 T1: Create the front end UI for cancelling any meetings

**Story:** Story 19 Meeting Cancellation

**Description:** Added a button to allow any user to cancel any of their upcoming meetings. Upon clicking of the button, a confirmation message will also appear to ensure that the user does indeed want to cancel their meetings. Please note that the term **appointment** is used in the user interface and is synonymous with the term **meeting**. Integrating this functionality with the backend is NOT in scope for this ticket and will be implemented in S19 T3. 

**Testing Criteria (how I tested the code):** 
1. Ran the code locally and verified that the Cancel button was available next to each upcoming appointment for both student and worker users (see Figure 1). I also clicked the button and ensured that a cancellation confirmation popup rendered as expected (see Figure 2). When the _No_ button is clicked, the appointment cancellation confirmation will disappear. However, if the _Yes_ button is clicked, an alert box will appear to let the user know that the appointment has not been cancelled (as it is not yet integrated the feature with the backend). When the user clicks the _Ok_ button, all of the popups will disappear and they will be returned to the home page. 
- STUDENT email: johndoe@gmail.com, password: a1234
- WORKER email: joshuabrooks@gmail.com, password: j1234

![image](https://user-images.githubusercontent.com/32720322/100404107-93216400-302e-11eb-8373-f2ac53db92e2.png)
**Figure 1.** Screenshot for the updated home page for a student user.

![image](https://user-images.githubusercontent.com/32720322/100404181-c06e1200-302e-11eb-8894-3f01144bf57c.png)
**Figure 2.** Screenshot of the Appointment Cancellation Confirmation popup.

![image](https://user-images.githubusercontent.com/32720322/100404618-cca69f00-302f-11eb-8f1f-8659aa2c6e04.png)
**Figure 3.** Screenshot of the temporary alert message shown to the user when they confirm the appointment cancellation (will be adjusted once the feature is properly integrated with the back end). 

2. Ran the unit tests in the front end and ensured 100% file coverage (and passing tests) for the `AppointmentList.js` component. Also checked to make sure that the `EmergencyDayCancellation.js`, `LogIn.js` and `Title.js` components still have 100% code coverage and the `CheckboxApplication.js` and `LogInForm.js` have above 95% coverage similar to the master branch. I also checked to make sure all tests are passing. The other tests are not set up yet (in the scope of another ticket) and thus the lower file coverage for the other front end files is expected.
3. Ran the automated server test codes and ensured that there was 100% file coverage (and passing tests) for all the unit tests.

**How Reviewers can Test Code:**
1. Run the code locally and ensure no complications when starting up (run the command `npm run-script start:dev` in the root folder OR run the command `npm start` if your node and npm versions are above 12.10.0 for node and 6.10.3 for npm).
a. Use student credentials such as `username: johndoe@gmail.com and password: a1234` and check to make sure that there is a Cancel button next to each upcoming appointment for the student. 
b. Use worker credentials such as `username: joshuabrooks@gmail.com and password: j1234` and check to make sure that there is a Cancel button next to each upcoming appointment for the student. 
c. For either or both users, click the button and ensure that the response is as expected (check above screenshots for the expected results).
2. Run the automated tests locally and ensure that all tests pass and have 100% file coverage. 
a. Navigate inside the `server` folder and run `npm test`. 
b. Navigate inside the `react-ui` folder and run `npm test`. All tests should pass and the `EmergencyDayCancellation.js`, `AppointmentList.js`, `LogIn.js` and `Title.js` components should have 100% file coverage whilst the `CheckboxApplication.js` and `LogInForm.js` have above 95% coverage (the rest are not set up yet and are in scope for another ticket).