### PR TITLE
S19 t3/integrate frontend backend cancelling meetings

### DIFF
--- a/react-ui/src/components/AppointmentList/AppointmentList.js
+++ b/react-ui/src/components/AppointmentList/AppointmentList.js
@@ -44,7 +44,13 @@ export default class AppointmentList extends Component {
       });
   }
 
-  async cancelAppointment(event) {
+  cancelAppointment(event) {
+    // Stores the required parameters in an object to be passed to the api.
+    const params = {
+      accessToken: this.props.user.accessToken,
+      appointmentId: event.target.id
+    };
+
     // Customizes the content in the cancel appointment popup.
     const options = {
       title: 'Appointment Cancellation Confirmation',
@@ -54,22 +60,17 @@ export default class AppointmentList extends Component {
           label: 'Yes',
           className: "yes-cancel-btn",
           onClick: () => {
-            alert("The appointment was NOT cancelled!\r\n\nThis feature is not fully integrated yet, but the ConnectMe team is working hard to finish it. We appreciate your patience!");
-
-            /* TO DO: UNCOMMENT LOGIC ONCE INTEGRATE WITH API.
-             // Stores whether the appointment was successfully cancelled in a variable. 
-            const isSuccessfullyCancelled = false;
-            // Stores the specific appointmentId as a variable for API call. 
-            const appointmentId = event.target.id;
-
-            // TO DO: Call the API to cancel the appointment
-            console.log('cancelAppointment', appointmentId);
-
-            // Display a success message if the appointment is successfully cancelled.
-            if (isSuccessfullyCancelled) alert('The appointment has been cancelled!');
-            // Else, let's the user know that the appointment was not cancelled successfully.
-            else alert('The appointment was NOT cancelled. Please try again.');
-            */
+            // Calls the api to cancel the appointment which returns true if the appointment was successfully cancelled and false otherwise. 
+            axios.get(`/api/cancel-specific-appointment/?${queryString.stringify(params)}`)
+              .then(res => {
+                // Display a success message if the appointment is successfully cancelled without any errors.
+                if (_.isNil(res.error) && res.data) {
+                  alert('The appointment has been cancelled!');
+                } else { // Else, let's the user know that the appointment was not cancelled successfully.
+                  alert('The appointment was NOT cancelled. Please try again.');
+                  console.log('Error occurred when calling the cancel appointment api: ', res.error);
+                }
+              });
           }
         },
         {

--- a/server/routes/private.js
+++ b/server/routes/private.js
@@ -197,8 +197,21 @@ router.get('/cancel-specific-day', async (req, res) => {
     res.send(isCancelledSuccessfully);
 });
 
-// Temporary stub to cancel a specific appointment that always returns false.
+// Endpoint to cancel a specific appointment.
 router.get('/cancel-specific-appointment', async (req, res) => {
+    // Checks the format of the passed in parameters.
+    const paramSchema = Joi.object({
+        appointmentId: Joi.number().integer().required(),
+    });
+
+    const appointmentId = req.query.appointmentId;
+
+    const { error } = paramSchema.validate({ appointmentId });
+
+    // Returns an error if the parameters are invalid. 
+    if (!_.isNil(error)) res.send(error);
+
+    // Temporarily hardcoded to return false for testing purposes. 
     res.send(false);
 });
 

--- a/server/routes/private.js
+++ b/server/routes/private.js
@@ -197,5 +197,9 @@ router.get('/cancel-specific-day', async (req, res) => {
     res.send(isCancelledSuccessfully);
 });
 
+// Temporary stub to cancel a specific appointment that always returns false.
+router.get('/cancel-specific-appointment', async (req, res) => {
+    res.send(false);
+});
 
 module.exports = router


### PR DESCRIPTION
**Scrum Board Ticket:** S19 T3: Integrate the front end and back end for cancelling any meetings

**Story:** Story 19 Meeting Cancellation

**Description:** Integrated the appointment cancellation front end with the back end api and created a backend stub to connect the front end with the back end. The logic for the back end endpoint will be implemented in S19 T2. As agreed upon with the developer working on S19 T2, the stub should be hardcoded to return false (a boolean return type) and accept the parameters of `accessToken` and `appointmentId`. Please note that the term **appointment** is used in the user interface and is synonymous with the term **meeting**.

**Testing Criteria (how I tested the code):** 
1. Ran the code locally and verified that the Cancel button was available next to each upcoming appointment for both student and worker users (see Figure 1). I also clicked the button and ensured that a cancellation confirmation popup rendered as expected (see Figure 2). When the _No_ button is clicked, the appointment cancellation confirmation will disappear. However, if the _Yes_ button is clicked, an alert box will appear to let the user know that the appointment has not been cancelled (as the backend api stub is hardcoded to return false). When the user clicks the _Ok_ button, all of the popups will disappear and they will be returned to the home page. 
- STUDENT email: johndoe@gmail.com, password: a1234
- WORKER email: joshuabrooks@gmail.com, password: j1234

![image](https://user-images.githubusercontent.com/32720322/100524216-58c9db00-3184-11eb-84ce-072d0f17562a.png)
**Figure 1.** Screenshot for the updated home page for a worker user.

![image](https://user-images.githubusercontent.com/32720322/100524228-65e6ca00-3184-11eb-9341-268ffcd98ca5.png)
**Figure 2.** Screenshot of the Appointment Cancellation Confirmation popup.

![image](https://user-images.githubusercontent.com/32720322/100524236-6f703200-3184-11eb-8469-d13dede03fca.png)
**Figure 3.** Screenshot of the error alert message shown to the user when they confirm the appointment cancellation (the api currently is hardcoded to return false).

2. Ran the unit tests in the front end and ensured 100% file coverage (and passing tests) for the `AppointmentList.js` component. Also checked to make sure that the `EmergencyDayCancellation.js`, `LogIn.js` and `Title.js` components still have 100% code coverage and the `CheckboxApplication.js` and `LogInForm.js` have above 95% coverage similar to the master branch. I also checked to make sure all tests are passing. The other tests are not set up yet (in the scope of another ticket) and thus the lower file coverage for the other front end files is expected.
3. Ran the automated server test codes and ensured that there was 100% file coverage (and passing tests) for all the unit tests.

**How Reviewers can Test Code:**
1. Run the code locally and ensure no complications when starting up (run the command `npm run-script start:dev` in the root folder OR run the command `npm start` if your node and npm versions are above 12.10.0 for node and 6.10.3 for npm).
a. Use student credentials such as `username: johndoe@gmail.com and password: a1234` and check to make sure that there is a Cancel button next to each upcoming appointment for the student. 
b. Use worker credentials such as `username: joshuabrooks@gmail.com and password: j1234` and check to make sure that there is a Cancel button next to each upcoming appointment for the student. 
c. For either or both users, click the button and ensure that the response is as expected (check above screenshots for the expected results).
2. Run the automated tests locally and ensure that all tests pass and have 100% file coverage. 
a. Navigate inside the `server` folder and run `npm test`. 
b. Navigate inside the `react-ui` folder and run `npm test`. All tests should pass and the `EmergencyDayCancellation.js`, `AppointmentList.js`, `LogIn.js` and `Title.js` components should have 100% file coverage whilst the `CheckboxApplication.js` and `LogInForm.js` have above 95% coverage (the rest are not set up yet and are in scope for another ticket).